### PR TITLE
Add guard around os.hostname

### DIFF
--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -1,13 +1,12 @@
 var pad = require('./pad.js');
 var os = require('os');
 
-function getHostname() {
+function getHostname () {
   try {
-    return os.hostname();
-  }
-  catch {
-    return '';
-  }
+      return os.hostname();
+  } catch (e) {
+      return '';
+    }
 }
 
 var padding = 2,

--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -1,9 +1,18 @@
 var pad = require('./pad.js');
+var os = require('os');
 
-var os = require('os'),
-    padding = 2,
+function getHostname() {
+  try {
+    return os.hostname();
+  }
+  catch {
+    return '';
+  }
+}
+
+var padding = 2,
     pid = pad(process.pid.toString(36), padding),
-    hostname = os.hostname(),
+    hostname = getHostname(),
     length = hostname.length,
     hostId = pad(hostname
       .split('')


### PR DESCRIPTION
This is to prevent a crash that occurs when calling this node API on Windows 7 - see https://github.com/bugsnag/bugsnag-js/issues/1783 

Although this hasn't been tested against Windows, I've manually tested that fingerprint/cuid generation still works when hostname is an empty string, and also ran both the `@bugsnag/cuid` and `@bugsnag/js` unit tests against the hardcoded fallback code.