### PR TITLE
Fall back to using environment variables when os.hostname fails

### DIFF
--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -5,7 +5,16 @@ function getHostname () {
   try {
       return os.hostname();
   } catch (e) {
-      return '';
+    /**
+     * This is most likely Windows 7 which is known to cause os.hostname() to break
+     * @see https://github.com/nodejs/node/issues/41297
+     * @see https://github.com/libuv/libuv/issues/3260
+     *
+     * Fallback to take hostname from environment variables
+     * @see https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/hostname#notes
+     */
+    // eslint-disable-next-line no-underscore-dangle
+    return process.env._CLUSTER_NETWORK_NAME_ || process.env.COMPUTERNAME || 'hostname';
     }
 }
 


### PR DESCRIPTION

v3.0.1 added a simple guard around `os.hostname` to prevent a crash on Windows 7 - however the original library authors have correctly pointed out that this significantly increases the likelihood of collisions on Win 7 - https://github.com/paralleldrive/cuid/pull/264#issuecomment-1212655531

This is a port of @FlyingDR's PR on the original cuid library (https://github.com/paralleldrive/cuid/pull/264) which improves that fix by attempting to fall back to environment variables when os.hostname fails.
