### PR TITLE
fix type declaration

### DIFF
--- a/cuid.d.ts
+++ b/cuid.d.ts
@@ -1,6 +1,10 @@
-declare module '@bugsnag/cuid' {
-    export function fingerprint(): string
-    export function isCuid(value: unknown): value is string
+declare function cuid(): string;
+declare namespace cuid {
+    function fingerprint(): string
+    function isCuid(value: unknown): value is string
 
-    export default function cuid(): string
+    export { fingerprint };
+    export { isCuid };
 }
+
+export = cuid;


### PR DESCRIPTION
this package uses a commonJS `module.export` so the types should use `export =`

This has been tested in the js performance repo against https://github.com/bugsnag/bugsnag-js-performance/pull/445 by manually updating the types in node_modules to as they are here and verifying the type errors are resolved