### PR TITLE
Release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.2.0] - 2025-02-18
+
+### Changed
+
+- Convert source code to ES module syntax and use rollup to build Common JS [#18](https://github.com/bugsnag/cuid/pull/18)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cuid",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Collision-resistant ids optimized for horizontal scaling and performance. For node and browsers.",
   "author": {
     "name": "Bugsnag",


### PR DESCRIPTION
### Changed

- Convert source code to ES module syntax and use rollup to build Common JS [#18](https://github.com/bugsnag/cuid/pull/18)