### PR TITLE
Add types field to package.json exports map

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,16 +4,16 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node: [12, 14, 16, 18, 20, 22]
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       - name: Checkout PR branch
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
       - run: npm install
       - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Add missing types field to package.json exports map [#22](https://github.com/bugsnag/cuid/pull/22)
+
 ## [3.2.1] - 2025-02-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "types": "cuid.d.ts",
   "exports": {
     ".": {
+      "types": "./cuid.d.ts",
       "import": "./index.esm.mjs",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
Adds the missing types field to the package.json exports map so that consuming TS packages in @bugsnag/js can find the types